### PR TITLE
Update NES_Label_Slider_v1.ino

### DIFF
--- a/NES_Label_Slider_v1/NES_Label_Slider_v1.ino
+++ b/NES_Label_Slider_v1/NES_Label_Slider_v1.ino
@@ -191,6 +191,8 @@ void taskBackLight(void * parameter)
       Serial.println("Press Button BackLight");
       
       currentBackLight += BACKLIGHT_FACTOR;
+          
+      delay(500);
 
       if (currentBackLight > BACKLIGHT_MAXIMUM)
         currentBackLight = BACKLIGHT_FACTOR;


### PR DESCRIPTION
evita que el valor de brillo suba de subito, por ejemplo de 10 a 70